### PR TITLE
修改在数字证书签发过程中表述不清楚

### DIFF
--- a/content/posts/go/grpc/2018-10-08-ca-tls.md
+++ b/content/posts/go/grpc/2018-10-08-ca-tls.md
@@ -27,13 +27,13 @@ tags:
 - 公钥
 - 密钥
 
-### 生成 Key
+### 生成CA自身的Key(私钥)
 
 ```
 openssl genrsa -out ca.key 2048
 ```
 
-### 生成密钥
+### 使用CA自己的私钥生成自签名证书
 
 ```
 openssl req -new -x509 -days 7200 -key ca.key -out ca.pem
@@ -75,7 +75,7 @@ to be sent with your certificate request
 A challenge password []:
 ```
 
-CSR 是 Cerificate Signing Request 的英文缩写，为证书请求文件。主要作用是 CA 会利用 CSR 文件进行签名使得攻击者无法伪装或篡改原有证书
+CSR 是 Cerificate Signing Request 的英文缩写，为证书请求文件。主要作用是:如果有客户(比如我们这个文章中需要通信的客户端和服务端) 需要CA生成数字证书，首先客户自己会使用自己的私钥来生成 CSR 文件，接下来客户就可以把CSR文件发送给CA，CA可以根据客户的 CSR 文件给客户签发数字证书。在本文的例子中，客户端和服务端拿到CA签发的数字证书后就可以进行TLS/SSL握手(使用数字证书相互鉴别身份，协商对称秘钥)，数字证书是PKI(公钥基础设施)中重要的概念之一，读者如果想深入可以学习公钥密码学。
 
 #### 基于 CA 签发
 


### PR DESCRIPTION
感觉在：数字证书生成的表述有点少，而且读起来不是很清楚：在用openssl工具生成的这几个文件的作用